### PR TITLE
fix: ensure tracking configuration consistency for specification and paged queries (#33)

### DIFF
--- a/Repository/Base/IRepo.cs
+++ b/Repository/Base/IRepo.cs
@@ -63,8 +63,8 @@ namespace Repo.Repository.Base
         Task<IEnumerable<TResult>> ExecuteTableValuedFunctionAsync<TResult>(string functionName, params object[] parameters) where TResult : class;
 
         // NUEVOS MÉTODOS - Paginación y Filtrado
-        Task<PagedResult<T>> GetPagedAsync(PagedRequest request, CancellationToken cancellationToken = default);
-        Task<PagedResult<T>> GetPagedAsync(Expression<Func<T, bool>> filter, PagedRequest request, CancellationToken cancellationToken = default);
+        Task<PagedResult<T>> GetPagedAsync(PagedRequest request, bool asNoTracking = false, CancellationToken cancellationToken = default);
+        Task<PagedResult<T>> GetPagedAsync(Expression<Func<T, bool>> filter, PagedRequest request, bool asNoTracking = false, CancellationToken cancellationToken = default);
 
         // NUEVOS MÉTODOS - Especificaciones
         Task<T?> GetBySpecAsync(ISpecification<T> spec, CancellationToken cancellationToken = default);

--- a/Repository/Base/RepoBase.cs
+++ b/Repository/Base/RepoBase.cs
@@ -381,11 +381,11 @@ namespace Repo.Repository.Base
         #endregion
 
         #region NUEVOS MÉTODOS - Paginación y Filtrado
-        public async Task<PagedResult<T>> GetPagedAsync(PagedRequest request, CancellationToken cancellationToken = default)
+        public async Task<PagedResult<T>> GetPagedAsync(PagedRequest request, bool asNoTracking = false, CancellationToken cancellationToken = default)
         {
             try
             {
-                var query = Table.AsQueryable();
+                var query = asNoTracking ? Table.AsNoTracking() : Table.AsQueryable();
 
                 // Aplica búsqueda si hay SearchTerm
                 if (!string.IsNullOrWhiteSpace(request.SearchTerm))
@@ -420,11 +420,11 @@ namespace Repo.Repository.Base
             }
         }
 
-        public async Task<PagedResult<T>> GetPagedAsync(Expression<Func<T, bool>> filter, PagedRequest request, CancellationToken cancellationToken = default)
+        public async Task<PagedResult<T>> GetPagedAsync(Expression<Func<T, bool>> filter, PagedRequest request, bool asNoTracking = false, CancellationToken cancellationToken = default)
         {
             try
             {
-                var query = Table.Where(filter);
+                var query = asNoTracking ? Table.AsNoTracking().Where(filter) : Table.Where(filter);
 
                 var totalCount = await query.CountAsync(cancellationToken);
                 var items = await query

--- a/Repository/Specifications/SpecificationEvaluator.cs
+++ b/Repository/Specifications/SpecificationEvaluator.cs
@@ -35,6 +35,12 @@ namespace Repo.Repository.Specifications
             query = spec.Includes.Aggregate(query, (current, include) => current.Include(include));
             query = spec.IncludeStrings.Aggregate(query, (current, include) => current.Include(include));
 
+            // Aplicar configuración de tracking
+            if (!spec.IsTrackingEnabled)
+            {
+                query = query.AsNoTracking();
+            }
+
             return query;
         }
     }


### PR DESCRIPTION
Closes #33

## Summary

This PR fixes inconsistent tracking behavior in specification-based and paged queries, ensuring they respect the `IsTrackingEnabled` flag from `BaseSpecification` and provide consistent `asNoTracking` parameters like other read methods.

## Changes

| File | Change |
|------|--------|
| `Repository/Specifications/SpecificationEvaluator.cs` | Now respects `IsTrackingEnabled` - applies `AsNoTracking()` when the spec flag is false |
| `Repository/Base/IRepo.cs` | Added `asNoTracking` parameter to both `GetPagedAsync` overloads |
| `Repository/Base/RepoBase.cs` | Implemented `asNoTracking` behavior in both `GetPagedAsync` methods |

## Behavior Fixed

### Specification-based queries now automatically respect tracking:
- `GetBySpecAsync`
- `GetAllBySpecAsync`
- `GetPagedBySpecAsync`
- `CountBySpecAsync`

All respect `spec.IsTrackingEnabled` from `BaseSpecification`.

### Paged queries now consistent with other reads:
- `GetPagedAsync(PagedRequest, bool asNoTracking = false, ...)`
- `GetPagedAsync(Expression<Func<T, bool>>, PagedRequest, bool asNoTracking = false, ...)`

Matches pattern from: `GetAllAsync`, `FindAsync`, `FirstOrDefaultAsync`

## Breaking Changes

None. All parameters default to `false` for backward compatibility.

## Test Plan

- [ ] Specification queries with `IsTrackingEnabled = false` use AsNoTracking
- [ ] Specification queries with `IsTrackingEnabled = true` use tracking
- [ ] GetPagedAsync with `asNoTracking = true` uses AsNoTracking
- [ ] GetPagedAsync with `asNoTracking = false` (default) uses tracking
- [ ] Existing code without new parameters continues to work

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Contributor Checklist

- [x] Linked an approved issue (Closes #33)
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers
