### PR TITLE
test: add soft delete, cache, and high-performance behavior tests (#35)

### DIFF
--- a/Repo.Tests/Base/CacheBehaviorTests.cs
+++ b/Repo.Tests/Base/CacheBehaviorTests.cs
@@ -1,0 +1,431 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Repo.Repository.Base;
+using Repo.Repository.Interfaces;
+
+namespace Repo.Tests.Base
+{
+    /// <summary>
+    /// Tests for Cache behavior (Issue #35).
+    /// Validates cache integration for GetById and GetAll operations.
+    /// </summary>
+    [TestFixture]
+    public class CacheBehaviorTests
+    {
+        private TestDbContext _context = null!;
+        private ILogger<RepoBase<CachedEntity, TestDbContext>> _logger = null!;
+        private FakeCacheService _cacheService = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var options = new DbContextOptionsBuilder<TestDbContext>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .Options;
+
+            _context = new TestDbContext(options);
+            _logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<RepoBase<CachedEntity, TestDbContext>>.Instance;
+            _cacheService = new FakeCacheService();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _context.Dispose();
+        }
+
+        #region GetByIdWithCacheAsync - int overload
+
+        [Test]
+        public async Task GetByIdWithCacheAsync_IntId_CacheMiss_FetchesFromDbAndStoresInCache()
+        {
+            // Arrange
+            var entity = new CachedEntity { Id = 1, Name = "Test Entity" };
+            _context.CachedEntities.Add(entity);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<CachedEntity, TestDbContext>(_context, _logger, _cacheService);
+
+            // Act
+            var result = await repo.GetByIdWithCacheAsync(1);
+
+            // Assert
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result!.Name, Is.EqualTo("Test Entity"));
+            Assert.That(_cacheService.GetCallCount($"CachedEntity:1"), Is.EqualTo(1));
+            Assert.That(_cacheService.SetCallCount($"CachedEntity:1"), Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task GetByIdWithCacheAsync_IntId_CacheHit_ReturnsFromCache()
+        {
+            // Arrange
+            var entity = new CachedEntity { Id = 2, Name = "Original" };
+            _context.CachedEntities.Add(entity);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<CachedEntity, TestDbContext>(_context, _logger, _cacheService);
+
+            // First call - cache miss
+            await repo.GetByIdWithCacheAsync(2);
+
+            // Modify entity in DB directly (bypassing cache)
+            entity.Name = "Modified";
+            _context.SaveChanges();
+
+            // Act - Second call should return cached version
+            var result = await repo.GetByIdWithCacheAsync(2);
+
+            // Assert - Should get original cached value
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result!.Name, Is.EqualTo("Original"));
+        }
+
+        [Test]
+        public async Task GetByIdWithCacheAsync_IntId_WithExpiration_SetsExpiration()
+        {
+            // Arrange
+            var entity = new CachedEntity { Id = 3, Name = "Test" };
+            _context.CachedEntities.Add(entity);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<CachedEntity, TestDbContext>(_context, _logger, _cacheService);
+            var expiration = TimeSpan.FromMinutes(5);
+
+            // Act
+            await repo.GetByIdWithCacheAsync(3, expiration);
+
+            // Assert
+            Assert.That(_cacheService.LastExpiration, Is.EqualTo(expiration));
+        }
+
+        #endregion
+
+        #region GetByIdWithCacheAsync - long overload
+
+        [Test]
+        public async Task GetByIdWithCacheAsync_LongId_CacheMiss_FetchesFromDb()
+        {
+            // Arrange
+            var entity = new CachedEntity { Id = 4, Name = "Test Entity" };
+            _context.CachedEntities.Add(entity);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<CachedEntity, TestDbContext>(_context, _logger, _cacheService);
+
+            // Act
+            var result = await repo.GetByIdWithCacheAsync(4L);
+
+            // Assert
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result!.Name, Is.EqualTo("Test Entity"));
+        }
+
+        [Test]
+        public async Task GetByIdWithCacheAsync_LongId_CacheHit_ReturnsFromCache()
+        {
+            // Arrange
+            var entity = new CachedEntity { Id = 5, Name = "Original" };
+            _context.CachedEntities.Add(entity);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<CachedEntity, TestDbContext>(_context, _logger, _cacheService);
+
+            // First call - cache miss
+            await repo.GetByIdWithCacheAsync(5L);
+
+            // Modify entity in DB
+            entity.Name = "Modified";
+            _context.SaveChanges();
+
+            // Act - Second call should return cached version
+            var result = await repo.GetByIdWithCacheAsync(5L);
+
+            // Assert
+            Assert.That(result!.Name, Is.EqualTo("Original"));
+        }
+
+        #endregion
+
+        #region GetByIdWithCacheAsync - No Cache Service
+
+        [Test]
+        public async Task GetByIdWithCacheAsync_NoCacheService_DelegatesToGetById()
+        {
+            // Arrange
+            var entity = new CachedEntity { Id = 6, Name = "Test Entity" };
+            _context.CachedEntities.Add(entity);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<CachedEntity, TestDbContext>(_context, _logger, null);
+
+            // Act
+            var result = await repo.GetByIdWithCacheAsync(6);
+
+            // Assert
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result!.Name, Is.EqualTo("Test Entity"));
+        }
+
+        #endregion
+
+        #region GetAllWithCacheAsync
+
+        [Test]
+        public async Task GetAllWithCacheAsync_CacheMiss_FetchesFromDbAndStoresInCache()
+        {
+            // Arrange
+            _context.CachedEntities.AddRange(
+                new CachedEntity { Id = 10, Name = "Entity1" },
+                new CachedEntity { Id = 11, Name = "Entity2" }
+            );
+            _context.SaveChanges();
+
+            var repo = new RepoBase<CachedEntity, TestDbContext>(_context, _logger, _cacheService);
+
+            // Act
+            var results = await repo.GetAllWithCacheAsync();
+
+            // Assert
+            Assert.That(results.Count(), Is.EqualTo(2));
+            Assert.That(_cacheService.GetCallCount("CachedEntity:All"), Is.EqualTo(1));
+            Assert.That(_cacheService.SetCallCount("CachedEntity:All"), Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task GetAllWithCacheAsync_CacheHit_ReturnsFromCache()
+        {
+            // Arrange
+            _context.CachedEntities.Add(new CachedEntity { Id = 12, Name = "Entity1" });
+            _context.SaveChanges();
+
+            var repo = new RepoBase<CachedEntity, TestDbContext>(_context, _logger, _cacheService);
+
+            // First call - cache miss
+            await repo.GetAllWithCacheAsync();
+
+            // Add new entity to DB
+            _context.CachedEntities.Add(new CachedEntity { Id = 13, Name = "Entity2" });
+            _context.SaveChanges();
+
+            // Act - Second call should return cached (stale) data
+            var results = await repo.GetAllWithCacheAsync();
+
+            // Assert - Should have only 1 entity (from cache)
+            Assert.That(results.Count(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task GetAllWithCacheAsync_WithExpiration_SetsExpiration()
+        {
+            // Arrange
+            _context.CachedEntities.Add(new CachedEntity { Id = 14, Name = "Test" });
+            _context.SaveChanges();
+
+            var repo = new RepoBase<CachedEntity, TestDbContext>(_context, _logger, _cacheService);
+            var expiration = TimeSpan.FromHours(1);
+
+            // Act
+            await repo.GetAllWithCacheAsync(expiration);
+
+            // Assert
+            Assert.That(_cacheService.LastExpiration, Is.EqualTo(expiration));
+        }
+
+        [Test]
+        public async Task GetAllWithCacheAsync_NoCacheService_DelegatesToGetAllAsync()
+        {
+            // Arrange
+            _context.CachedEntities.Add(new CachedEntity { Id = 15, Name = "Test" });
+            _context.SaveChanges();
+
+            var repo = new RepoBase<CachedEntity, TestDbContext>(_context, _logger, null);
+
+            // Act
+            var results = await repo.GetAllWithCacheAsync();
+
+            // Assert
+            Assert.That(results.Count(), Is.EqualTo(1));
+        }
+
+        #endregion
+
+        #region InvalidateCacheAsync
+
+        [Test]
+        public async Task InvalidateCacheAsync_WithPattern_RemovesByPattern()
+        {
+            // Arrange
+            var repo = new RepoBase<CachedEntity, TestDbContext>(_context, _logger, _cacheService);
+            await repo.GetByIdWithCacheAsync(20);
+            await repo.GetByIdWithCacheAsync(21);
+
+            // Act
+            await repo.InvalidateCacheAsync("*");
+
+            // Assert
+            Assert.That(_cacheService.RemoveByPatternCallCount("CachedEntity:*"), Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task InvalidateCacheAsync_WithSpecificPattern_RemovesMatching()
+        {
+            // Arrange
+            var repo = new RepoBase<CachedEntity, TestDbContext>(_context, _logger, _cacheService);
+
+            // Act
+            await repo.InvalidateCacheAsync("20");
+
+            // Assert
+            Assert.That(_cacheService.RemoveByPatternCallCount("CachedEntity:20"), Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task InvalidateCacheAsync_NoCacheService_DoesNotThrow()
+        {
+            // Arrange
+            var repo = new RepoBase<CachedEntity, TestDbContext>(_context, _logger, null);
+
+            // Act & Assert - Should not throw
+            Assert.DoesNotThrowAsync(async () => await repo.InvalidateCacheAsync("*"));
+        }
+
+        #endregion
+
+        #region Cache Key Generation
+
+        [Test]
+        public async Task GetByIdWithCacheAsync_GeneratesCorrectCacheKey()
+        {
+            // Arrange
+            var entity = new CachedEntity { Id = 100, Name = "Test" };
+            _context.CachedEntities.Add(entity);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<CachedEntity, TestDbContext>(_context, _logger, _cacheService);
+
+            // Act
+            await repo.GetByIdWithCacheAsync(100);
+
+            // Assert
+            Assert.That(_cacheService.LastGetKey, Is.EqualTo("CachedEntity:100"));
+        }
+
+        [Test]
+        public async Task GetAllWithCacheAsync_GeneratesCorrectCacheKey()
+        {
+            // Arrange
+            _context.CachedEntities.Add(new CachedEntity { Id = 101, Name = "Test" });
+            _context.SaveChanges();
+
+            var repo = new RepoBase<CachedEntity, TestDbContext>(_context, _logger, _cacheService);
+
+            // Act
+            await repo.GetAllWithCacheAsync();
+
+            // Assert
+            Assert.That(_cacheService.LastGetKey, Is.EqualTo("CachedEntity:All"));
+        }
+
+        #endregion
+
+        #region Test Infrastructure
+
+        public class TestDbContext : DbContext
+        {
+            public DbSet<CachedEntity> CachedEntities { get; set; } = null!;
+
+            public TestDbContext(DbContextOptions<TestDbContext> options) : base(options)
+            {
+            }
+        }
+
+        public class CachedEntity
+        {
+            public int Id { get; set; }
+            public string Name { get; set; } = string.Empty;
+        }
+
+        /// <summary>
+        /// Fake cache service for testing cache behavior without external dependencies.
+        /// </summary>
+        public class FakeCacheService : ICacheService
+        {
+            private readonly Dictionary<string, object> _cache = new();
+            private readonly Dictionary<string, int> _getCounts = new();
+            private readonly Dictionary<string, int> _setCounts = new();
+            private readonly Dictionary<string, int> _removeByPatternCounts = new();
+
+            public string? LastGetKey { get; private set; }
+            public TimeSpan? LastExpiration { get; private set; }
+
+            public Task<T?> GetAsync<T>(string key)
+            {
+                LastGetKey = key;
+                _getCounts[key] = _getCounts.GetValueOrDefault(key) + 1;
+                
+                if (_cache.TryGetValue(key, out var value))
+                {
+                    return Task.FromResult((T?)value);
+                }
+                return Task.FromResult(default(T?));
+            }
+
+            public Task SetAsync<T>(string key, T value, TimeSpan? expiration = null)
+            {
+                _cache[key] = value!;
+                _setCounts[key] = _setCounts.GetValueOrDefault(key) + 1;
+                LastExpiration = expiration;
+                return Task.CompletedTask;
+            }
+
+            public Task RemoveAsync(string key)
+            {
+                _cache.Remove(key);
+                return Task.CompletedTask;
+            }
+
+            public Task RemoveByPatternAsync(string pattern)
+            {
+                _removeByPatternCounts[pattern] = _removeByPatternCounts.GetValueOrDefault(pattern) + 1;
+                
+                // Simple wildcard implementation for testing
+                var keysToRemove = _cache.Keys
+                    .Where(k => pattern == "*" || k.Contains(pattern.TrimEnd('*').TrimStart('*')))
+                    .ToList();
+                
+                foreach (var key in keysToRemove)
+                {
+                    _cache.Remove(key);
+                }
+                
+                return Task.CompletedTask;
+            }
+
+            public Task<bool> ExistsAsync(string key)
+            {
+                return Task.FromResult(_cache.ContainsKey(key));
+            }
+
+            public async Task<T> GetOrSetAsync<T>(string key, Func<Task<T>> factory, TimeSpan? expiration = null)
+            {
+                var cached = await GetAsync<T>(key);
+                if (cached != null)
+                {
+                    return cached;
+                }
+
+                var value = await factory();
+                await SetAsync(key, value, expiration);
+                return value;
+            }
+
+            public int GetCallCount(string key) => _getCounts.GetValueOrDefault(key);
+            public int SetCallCount(string key) => _setCounts.GetValueOrDefault(key);
+            public int RemoveByPatternCallCount(string pattern) => _removeByPatternCounts.GetValueOrDefault(pattern);
+        }
+
+        #endregion
+    }
+}

--- a/Repo.Tests/Base/HighPerformanceRepoTests.cs
+++ b/Repo.Tests/Base/HighPerformanceRepoTests.cs
@@ -1,0 +1,712 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Repo.Repository.Base;
+using Repo.Repository.Interfaces;
+using System.Data;
+
+namespace Repo.Tests.Base
+{
+    /// <summary>
+    /// Tests for HighPerformanceRepo behavior (Issue #35).
+    /// Validates high-performance operations, metrics, and configuration.
+    /// Note: Bulk operations require SQLite real database connection.
+    /// </summary>
+    [TestFixture]
+    public class HighPerformanceRepoTests
+    {
+        private TestDbContext _context = null!;
+        private ILogger<HighPerformanceRepo<HighPerfEntity, TestDbContext>> _logger = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // Use SQLite in-memory mode for high-performance tests requiring real SQL connection
+            var connection = new SqliteConnection("DataSource=:memory:");
+            connection.Open();
+
+            var options = new DbContextOptionsBuilder<TestDbContext>()
+                .UseSqlite(connection)
+                .Options;
+
+            _context = new TestDbContext(options);
+            _context.Database.EnsureCreated();
+            _logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<HighPerformanceRepo<HighPerfEntity, TestDbContext>>.Instance;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _context.Dispose();
+        }
+
+        #region Constructor and Configuration
+
+        [Test]
+        public void Constructor_WithDefaultParameters_CreatesInstance()
+        {
+            // Act
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+
+            // Assert
+            Assert.That(repo, Is.Not.Null);
+            Assert.That(repo, Is.InstanceOf<IHighPerformanceRepo<HighPerfEntity>>());
+        }
+
+        [Test]
+        public void Constructor_WithCustomParameters_CreatesInstance()
+        {
+            // Act
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(
+                _context, _logger, null, maxConcurrency: 8, maxBatchSize: 500, batchTimeoutMs: 1000);
+
+            // Assert
+            Assert.That(repo, Is.Not.Null);
+        }
+
+        #endregion
+
+        #region ConfigureForHighPerformance
+
+        [Test]
+        public void ConfigureForHighPerformance_SetsTrackingBehavior()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+
+            // Act
+            repo.ConfigureForHighPerformance(commandTimeout: 120, enableRetryOnFailure: false);
+
+            // Assert
+            Assert.That(_context.ChangeTracker.QueryTrackingBehavior, Is.EqualTo(QueryTrackingBehavior.NoTracking));
+            Assert.That(_context.ChangeTracker.AutoDetectChangesEnabled, Is.False);
+        }
+
+        [Test]
+        public void ConfigureForHighPerformance_DefaultParameters_Works()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+
+            // Act & Assert - Should not throw
+            Assert.DoesNotThrow(() => repo.ConfigureForHighPerformance());
+        }
+
+        #endregion
+
+        #region ClearContextAsync
+
+        [Test]
+        public async Task ClearContextAsync_ClearsChangeTracker()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            _context.HighPerfEntities.Add(new HighPerfEntity { Name = "Test" });
+            Assert.That(_context.ChangeTracker.Entries().Count(), Is.EqualTo(1));
+
+            // Act
+            await repo.ClearContextAsync();
+
+            // Assert
+            Assert.That(_context.ChangeTracker.Entries().Count(), Is.EqualTo(0));
+        }
+
+        #endregion
+
+        #region ExecuteWithMetricsAsync - Action overload
+
+        [Test]
+        public async Task ExecuteWithMetricsAsync_Action_ReturnsMetrics()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            var operationExecuted = false;
+
+            // Act
+            var metrics = await repo.ExecuteWithMetricsAsync(async () =>
+            {
+                await Task.Delay(10);
+                operationExecuted = true;
+            });
+
+            // Assert
+            Assert.That(operationExecuted, Is.True);
+            Assert.That(metrics, Is.Not.Null);
+            Assert.That(metrics.ExecutionTime, Is.GreaterThan(TimeSpan.Zero));
+            Assert.That(metrics.MemoryUsageBefore, Is.GreaterThanOrEqualTo(0));
+            Assert.That(metrics.MemoryUsageAfter, Is.GreaterThanOrEqualTo(0));
+        }
+
+        [Test]
+        public void ExecuteWithMetricsAsync_Action_Throws_PreservesException()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+
+            // Act & Assert
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await repo.ExecuteWithMetricsAsync(async () =>
+                {
+                    await Task.CompletedTask;
+                    throw new InvalidOperationException("Test error");
+                });
+            });
+
+            Assert.That(ex!.Message, Is.EqualTo("Test error"));
+        }
+
+        #endregion
+
+        #region ExecuteWithMetricsAsync - Func<TResult> overload
+
+        [Test]
+        public async Task ExecuteWithMetricsAsync_Func_ReturnsResultAndMetrics()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+
+            // Act
+            var (result, metrics) = await repo.ExecuteWithMetricsAsync(async () =>
+            {
+                await Task.Delay(10);
+                return 42;
+            });
+
+            // Assert
+            Assert.That(result, Is.EqualTo(42));
+            Assert.That(metrics, Is.Not.Null);
+            Assert.That(metrics.ExecutionTime, Is.GreaterThan(TimeSpan.Zero));
+        }
+
+        [Test]
+        public void ExecuteWithMetricsAsync_Func_Throws_PreservesException()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+
+            // Act & Assert
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await repo.ExecuteWithMetricsAsync(async () =>
+                {
+                    await Task.CompletedTask;
+                    throw new InvalidOperationException("Test error");
+                });
+            });
+
+            Assert.That(ex!.Message, Is.EqualTo("Test error"));
+        }
+
+        #endregion
+
+        #region ProcessParallelAsync
+
+        [Test]
+        public async Task ProcessParallelAsync_ProcessesAllItems()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            var items = Enumerable.Range(1, 10).Select(i => new HighPerfEntity { Id = i, Name = $"Item{i}" }).ToList();
+            var processedItems = new List<string>();
+
+            // Act
+            await repo.ProcessParallelAsync(items, async item =>
+            {
+                await Task.Delay(1);
+                lock (processedItems)
+                {
+                    processedItems.Add(item.Name);
+                }
+                return item.Name;
+            }, maxConcurrency: 4);
+
+            // Assert
+            Assert.That(processedItems.Count, Is.EqualTo(10));
+            Assert.That(processedItems, Is.EquivalentTo(items.Select(i => i.Name)));
+        }
+
+        [Test]
+        public async Task ProcessParallelAsync_EmptyCollection_CompletesWithoutError()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            var items = new List<HighPerfEntity>();
+
+            // Act & Assert - Should not throw
+            await repo.ProcessParallelAsync(items, async item =>
+            {
+                await Task.CompletedTask;
+                return item.Name;
+            });
+        }
+
+        [Test]
+        public void ProcessParallelAsync_ThrowsException_PropagatesError()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            var items = new List<HighPerfEntity> { new() { Name = "Item1" } };
+
+            // Act & Assert
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await repo.ProcessParallelAsync(items, async _ =>
+                {
+                    await Task.CompletedTask;
+                    throw new InvalidOperationException("Test error");
+                });
+            });
+        }
+
+        #endregion
+
+        #region ExecuteInTransactionAsync
+
+        [Test]
+        public async Task ExecuteInTransactionAsync_CommitsOnSuccess()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+
+            // Act
+            var result = await repo.ExecuteInTransactionAsync(async () =>
+            {
+                _context.HighPerfEntities.Add(new HighPerfEntity { Name = "Transaction Test" });
+                await _context.SaveChangesAsync();
+                return 42;
+            });
+
+            // Assert
+            Assert.That(result, Is.EqualTo(42));
+            Assert.That(_context.HighPerfEntities.Count(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ExecuteInTransactionAsync_RollsBackOnException()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+
+            // Act & Assert
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await repo.ExecuteInTransactionAsync(async () =>
+                {
+                    _context.HighPerfEntities.Add(new HighPerfEntity { Name = "Transaction Test" });
+                    await _context.SaveChangesAsync();
+                    throw new InvalidOperationException("Test error");
+                });
+            });
+
+            // Assert - Transaction should have rolled back
+            Assert.That(_context.HighPerfEntities.Count(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task ExecuteInTransactionAsync_WithIsolationLevel_UsesSpecifiedLevel()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+
+            // Act - Should not throw with explicit isolation level
+            var result = await repo.ExecuteInTransactionAsync(async () =>
+            {
+                await Task.CompletedTask;
+                return 123;
+            }, IsolationLevel.ReadCommitted);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(123));
+        }
+
+        #endregion
+
+        #region ExecuteDistributedTransactionAsync
+
+        [Test]
+        public async Task ExecuteDistributedTransactionAsync_ExecutesAllOperations()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            var operationsExecuted = new List<int>();
+
+            // Act
+            await repo.ExecuteDistributedTransactionAsync(
+                async () => { await Task.Delay(1); operationsExecuted.Add(1); },
+                async () => { await Task.Delay(1); operationsExecuted.Add(2); },
+                async () => { await Task.Delay(1); operationsExecuted.Add(3); }
+            );
+
+            // Assert
+            Assert.That(operationsExecuted, Is.EquivalentTo(new[] { 1, 2, 3 }));
+        }
+
+        [Test]
+        public async Task ExecuteDistributedTransactionAsync_EmptyOperations_Completes()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+
+            // Act & Assert - Should not throw
+            await repo.ExecuteDistributedTransactionAsync();
+        }
+
+        #endregion
+
+        #region GetPagedOptimizedAsync
+
+        [Test]
+        public async Task GetPagedOptimizedAsync_ReturnsPagedResults()
+        {
+            // Arrange
+            for (int i = 1; i <= 25; i++)
+            {
+                _context.HighPerfEntities.Add(new HighPerfEntity { Name = $"Entity{i}" });
+            }
+            _context.SaveChanges();
+
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            var request = new Repo.Repository.Models.PagedRequest { PageNumber = 1, PageSize = 10 };
+
+            // Act
+            var result = await repo.GetPagedOptimizedAsync(request);
+
+            // Assert
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Data.Count, Is.EqualTo(10));
+            Assert.That(result.TotalCount, Is.EqualTo(25));
+            Assert.That(result.TotalPages, Is.EqualTo(3));
+        }
+
+        [Test]
+        public async Task GetPagedOptimizedAsync_WithFilter_ReturnsFilteredResults()
+        {
+            // Arrange
+            for (int i = 1; i <= 10; i++)
+            {
+                _context.HighPerfEntities.Add(new HighPerfEntity { Name = $"Entity{i}", Value = i });
+            }
+            _context.SaveChanges();
+
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            var request = new Repo.Repository.Models.PagedRequest { PageNumber = 1, PageSize = 10 };
+
+            // Act
+            var result = await repo.GetPagedOptimizedAsync(request, e => e.Value > 5);
+
+            // Assert
+            Assert.That(result.Data.Count, Is.EqualTo(5));
+            Assert.That(result.TotalCount, Is.EqualTo(5));
+        }
+
+        [Test]
+        public async Task GetPagedOptimizedAsync_SecondPage_ReturnsCorrectPage()
+        {
+            // Arrange
+            for (int i = 1; i <= 25; i++)
+            {
+                _context.HighPerfEntities.Add(new HighPerfEntity { Name = $"Entity{i}" });
+            }
+            _context.SaveChanges();
+
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            var request = new Repo.Repository.Models.PagedRequest { PageNumber = 2, PageSize = 10 };
+
+            // Act
+            var result = await repo.GetPagedOptimizedAsync(request);
+
+            // Assert
+            Assert.That(result.Page, Is.EqualTo(2));
+            Assert.That(result.Data.Count, Is.EqualTo(10));
+        }
+
+        #endregion
+
+        #region Bulk Operations (Requires real SQL database)
+
+        [Test]
+        public async Task BulkInsertAsync_InsertsEntities()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            var entities = Enumerable.Range(1, 100)
+                .Select(i => new HighPerfEntity { Name = $"BulkEntity{i}" })
+                .ToList();
+
+            // Act
+            var result = await repo.BulkInsertAsync(entities, batchSize: 50);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(100));
+            Assert.That(_context.HighPerfEntities.Count(), Is.EqualTo(100));
+        }
+
+        [Test]
+        public async Task BulkInsertAsync_EmptyList_ReturnsZero()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            var entities = new List<HighPerfEntity>();
+
+            // Act
+            var result = await repo.BulkInsertAsync(entities);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task BulkUpdateAsync_UpdatesEntities()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            var entities = Enumerable.Range(1, 50)
+                .Select(i => new HighPerfEntity { Name = $"Original{i}" })
+                .ToList();
+            await repo.BulkInsertAsync(entities);
+
+            // Modify entities
+            foreach (var entity in entities)
+            {
+                entity.Name = $"Updated{entity.Id}";
+            }
+
+            // Act
+            var result = await repo.BulkUpdateAsync(entities, batchSize: 25);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(50));
+        }
+
+        [Test]
+        public async Task BulkDeleteAsync_DeletesEntities()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            var entities = Enumerable.Range(1, 50)
+                .Select(i => new HighPerfEntity { Name = $"ToDelete{i}" })
+                .ToList();
+            await repo.BulkInsertAsync(entities);
+
+            // Act
+            var result = await repo.BulkDeleteAsync(entities, batchSize: 25);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(50));
+            Assert.That(_context.HighPerfEntities.Count(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task BulkDeleteAsync_WithPredicate_DeletesMatchingEntities()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            for (int i = 1; i <= 20; i++)
+            {
+                _context.HighPerfEntities.Add(new HighPerfEntity { Name = $"Entity{i}", Value = i });
+            }
+            _context.SaveChanges();
+
+            // Act
+            var result = await repo.BulkDeleteAsync(e => e.Value > 10);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(10));
+            Assert.That(_context.HighPerfEntities.Count(), Is.EqualTo(10));
+        }
+
+        [Test]
+        public async Task BulkDeleteAsync_PredicateNoMatches_ReturnsZero()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            _context.HighPerfEntities.Add(new HighPerfEntity { Name = "Entity", Value = 5 });
+            _context.SaveChanges();
+
+            // Act
+            var result = await repo.BulkDeleteAsync(e => e.Value > 100);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task BulkMergeAsync_InsertsAndUpdatesEntities()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            
+            // Insert initial entities
+            var existing = Enumerable.Range(1, 10)
+                .Select(i => new HighPerfEntity { Name = $"Existing{i}" })
+                .ToList();
+            await repo.BulkInsertAsync(existing);
+
+            // Prepare merge list (some exist, some new)
+            var mergeEntities = new List<HighPerfEntity>();
+            for (int i = 1; i <= 20; i++)
+            {
+                mergeEntities.Add(new HighPerfEntity 
+                { 
+                    Id = i <= 10 ? existing[i - 1].Id : 0,
+                    Name = $"Merged{i}" 
+                });
+            }
+
+            // Act
+            var result = await repo.BulkMergeAsync(mergeEntities, batchSize: 15);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(20));
+        }
+
+        #endregion
+
+        #region StreamAsync
+
+        [Test]
+        public async Task StreamAsync_ReturnsAllEntities()
+        {
+            // Arrange
+            for (int i = 1; i <= 100; i++)
+            {
+                _context.HighPerfEntities.Add(new HighPerfEntity { Name = $"StreamEntity{i}", Value = i });
+            }
+            _context.SaveChanges();
+
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            var count = 0;
+
+            // Act
+            await foreach (var entity in repo.StreamAsync())
+            {
+                count++;
+            }
+
+            // Assert
+            Assert.That(count, Is.EqualTo(100));
+        }
+
+        [Test]
+        public async Task StreamAsync_WithFilter_ReturnsFilteredEntities()
+        {
+            // Arrange
+            for (int i = 1; i <= 50; i++)
+            {
+                _context.HighPerfEntities.Add(new HighPerfEntity { Name = $"StreamEntity{i}", Value = i });
+            }
+            _context.SaveChanges();
+
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            var count = 0;
+
+            // Act
+            await foreach (var entity in repo.StreamAsync(e => e.Value > 40))
+            {
+                count++;
+            }
+
+            // Assert
+            Assert.That(count, Is.EqualTo(10));
+        }
+
+        #endregion
+
+        #region ProcessBatchAsync
+
+        [Test]
+        public async Task ProcessBatchAsync_ProcessesAllBatches()
+        {
+            // Arrange
+            for (int i = 1; i <= 50; i++)
+            {
+                _context.HighPerfEntities.Add(new HighPerfEntity { Name = $"BatchEntity{i}", Value = i });
+            }
+            _context.SaveChanges();
+
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            var processedCount = 0;
+
+            // Act
+            await repo.ProcessBatchAsync(
+                e => e.Value > 0,
+                async batch =>
+                {
+                    processedCount += batch.Count();
+                    await Task.CompletedTask;
+                    return batch.Count();
+                },
+                batchSize: 10,
+                maxConcurrency: 2);
+
+            // Assert
+            Assert.That(processedCount, Is.EqualTo(50));
+        }
+
+        [Test]
+        public async Task ProcessBatchAsync_WithFilter_ProcessesMatchingOnly()
+        {
+            // Arrange
+            for (int i = 1; i <= 50; i++)
+            {
+                _context.HighPerfEntities.Add(new HighPerfEntity { Name = $"BatchEntity{i}", Value = i });
+            }
+            _context.SaveChanges();
+
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+            var processedCount = 0;
+
+            // Act
+            await repo.ProcessBatchAsync(
+                e => e.Value > 40,
+                async batch =>
+                {
+                    processedCount += batch.Count();
+                    await Task.CompletedTask;
+                    return batch.Count();
+                },
+                batchSize: 5);
+
+            // Assert
+            Assert.That(processedCount, Is.EqualTo(10));
+        }
+
+        #endregion
+
+        #region Dispose
+
+        [Test]
+        public void Dispose_DoesNotThrow()
+        {
+            // Arrange
+            var repo = new HighPerformanceRepo<HighPerfEntity, TestDbContext>(_context, _logger);
+
+            // Act & Assert - Should not throw
+            Assert.DoesNotThrow(() => repo.Dispose());
+        }
+
+        #endregion
+
+        #region Test Infrastructure
+
+        public class TestDbContext : DbContext
+        {
+            public DbSet<HighPerfEntity> HighPerfEntities { get; set; } = null!;
+
+            public TestDbContext(DbContextOptions<TestDbContext> options) : base(options)
+            {
+            }
+        }
+
+        public class HighPerfEntity
+        {
+            public int Id { get; set; }
+            public string Name { get; set; } = string.Empty;
+            public int Value { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/Repo.Tests/Base/SoftDeleteBehaviorTests.cs
+++ b/Repo.Tests/Base/SoftDeleteBehaviorTests.cs
@@ -1,0 +1,371 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Repo.Repository.Base;
+using Repo.Repository.Interfaces;
+
+namespace Repo.Tests.Base
+{
+    /// <summary>
+    /// Tests for Soft Delete behavior (Issue #35).
+    /// Validates soft delete, restore, and retrieval of deleted entities.
+    /// </summary>
+    [TestFixture]
+    public class SoftDeleteBehaviorTests
+    {
+        private TestDbContext _context = null!;
+        private ILogger<RepoBase<SoftDeleteEntity, TestDbContext>> _logger = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var options = new DbContextOptionsBuilder<TestDbContext>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .Options;
+
+            _context = new TestDbContext(options);
+            _logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<RepoBase<SoftDeleteEntity, TestDbContext>>.Instance;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _context.Dispose();
+        }
+
+        #region SoftDeleteAsync - int ID overload
+
+        [Test]
+        public async Task SoftDeleteAsync_IntId_SetsIsDeletedTrue()
+        {
+            // Arrange
+            var entity = new SoftDeleteEntity { Id = 1, Name = "Test Entity" };
+            _context.SoftDeleteEntities.Add(entity);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<SoftDeleteEntity, TestDbContext>(_context, _logger);
+
+            // Act
+            var result = await repo.SoftDeleteAsync(1, "TestUser");
+
+            // Assert
+            Assert.That(result, Is.EqualTo(1));
+            Assert.That(entity.IsDeleted, Is.True);
+            Assert.That(entity.DeletedAt, Is.Not.Null);
+            Assert.That(entity.DeletedBy, Is.EqualTo("TestUser"));
+        }
+
+        [Test]
+        public async Task SoftDeleteAsync_IntId_WithoutDeletedBy_SetsIsDeleted()
+        {
+            // Arrange
+            var entity = new SoftDeleteEntity { Id = 2, Name = "Test Entity" };
+            _context.SoftDeleteEntities.Add(entity);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<SoftDeleteEntity, TestDbContext>(_context, _logger);
+
+            // Act
+            var result = await repo.SoftDeleteAsync(2);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(1));
+            Assert.That(entity.IsDeleted, Is.True);
+            Assert.That(entity.DeletedAt, Is.Not.Null);
+            Assert.That(entity.DeletedBy, Is.Null);
+        }
+
+        #endregion
+
+        #region SoftDeleteAsync - long ID overload
+
+        [Test]
+        public async Task SoftDeleteAsync_LongId_SetsIsDeletedTrue()
+        {
+            // Arrange
+            var entity = new SoftDeleteEntity { Id = 3, Name = "Test Entity" };
+            _context.SoftDeleteEntities.Add(entity);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<SoftDeleteEntity, TestDbContext>(_context, _logger);
+
+            // Act
+            var result = await repo.SoftDeleteAsync(3L, "TestUser");
+
+            // Assert
+            Assert.That(result, Is.EqualTo(1));
+            Assert.That(entity.IsDeleted, Is.True);
+            Assert.That(entity.DeletedAt, Is.Not.Null);
+            Assert.That(entity.DeletedBy, Is.EqualTo("TestUser"));
+        }
+
+        #endregion
+
+        #region SoftDeleteAsync - Entity overload
+
+        [Test]
+        public async Task SoftDeleteAsync_Entity_SetsIsDeletedTrue()
+        {
+            // Arrange
+            var entity = new SoftDeleteEntity { Id = 4, Name = "Test Entity" };
+            _context.SoftDeleteEntities.Add(entity);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<SoftDeleteEntity, TestDbContext>(_context, _logger);
+
+            // Act
+            var result = await repo.SoftDeleteAsync(entity, "TestUser");
+
+            // Assert
+            Assert.That(result, Is.EqualTo(1));
+            Assert.That(entity.IsDeleted, Is.True);
+            Assert.That(entity.DeletedAt, Is.Not.Null);
+            Assert.That(entity.DeletedBy, Is.EqualTo("TestUser"));
+        }
+
+        [Test]
+        public async Task SoftDeleteAsync_Entity_WithoutDeletedBy_SetsIsDeleted()
+        {
+            // Arrange
+            var entity = new SoftDeleteEntity { Id = 5, Name = "Test Entity" };
+            _context.SoftDeleteEntities.Add(entity);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<SoftDeleteEntity, TestDbContext>(_context, _logger);
+
+            // Act
+            var result = await repo.SoftDeleteAsync(entity);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(1));
+            Assert.That(entity.IsDeleted, Is.True);
+            Assert.That(entity.DeletedAt, Is.Not.Null);
+        }
+
+        #endregion
+
+        #region SoftDeleteAsync - Non-ISoftDelete fallback
+
+        [Test]
+        public async Task SoftDeleteAsync_NonSoftDeleteEntity_PerformsHardDelete()
+        {
+            // Arrange
+            var nonSoftDeleteLogger = Microsoft.Extensions.Logging.Abstractions.NullLogger<RepoBase<NonSoftDeleteEntity, TestDbContext>>.Instance;
+            var entity = new NonSoftDeleteEntity { Id = 1, Name = "Test Entity" };
+            _context.NonSoftDeleteEntities.Add(entity);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<NonSoftDeleteEntity, TestDbContext>(_context, nonSoftDeleteLogger);
+
+            // Act
+            var result = await repo.SoftDeleteAsync(1, "TestUser");
+
+            // Assert - Should hard delete since entity doesn't implement ISoftDelete
+            Assert.That(result, Is.EqualTo(1));
+            Assert.That(_context.NonSoftDeleteEntities.Find(1), Is.Null);
+        }
+
+        #endregion
+
+        #region GetAllIncludingDeletedAsync
+
+        [Test]
+        public async Task GetAllIncludingDeletedAsync_ReturnsDeletedAndNonDeleted()
+        {
+            // Arrange
+            var entity1 = new SoftDeleteEntity { Id = 10, Name = "Active" };
+            var entity2 = new SoftDeleteEntity { Id = 11, Name = "Deleted", IsDeleted = true, DeletedAt = DateTime.UtcNow };
+            _context.SoftDeleteEntities.AddRange(entity1, entity2);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<SoftDeleteEntity, TestDbContext>(_context, _logger);
+
+            // Act
+            var results = await repo.GetAllIncludingDeletedAsync();
+
+            // Assert
+            Assert.That(results.Count(), Is.EqualTo(2));
+        }
+
+        [Test]
+        public async Task GetAllIncludingDeletedAsync_NonSoftDeleteEntity_ReturnsAll()
+        {
+            // Arrange
+            var nonSoftDeleteLogger = Microsoft.Extensions.Logging.Abstractions.NullLogger<RepoBase<NonSoftDeleteEntity, TestDbContext>>.Instance;
+            var entity1 = new NonSoftDeleteEntity { Id = 10, Name = "Entity1" };
+            var entity2 = new NonSoftDeleteEntity { Id = 11, Name = "Entity2" };
+            _context.NonSoftDeleteEntities.AddRange(entity1, entity2);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<NonSoftDeleteEntity, TestDbContext>(_context, nonSoftDeleteLogger);
+
+            // Act
+            var results = await repo.GetAllIncludingDeletedAsync();
+
+            // Assert - For non-ISoftDelete entities, delegates to GetAllAsync
+            Assert.That(results.Count(), Is.EqualTo(2));
+        }
+
+        #endregion
+
+        #region RestoreAsync - int ID overload
+
+        [Test]
+        public async Task RestoreAsync_IntId_RestoresDeletedEntity()
+        {
+            // Arrange
+            var entity = new SoftDeleteEntity 
+            { 
+                Id = 20, 
+                Name = "Deleted Entity",
+                IsDeleted = true,
+                DeletedAt = DateTime.UtcNow,
+                DeletedBy = "TestUser"
+            };
+            _context.SoftDeleteEntities.Add(entity);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<SoftDeleteEntity, TestDbContext>(_context, _logger);
+
+            // Act
+            var result = await repo.RestoreAsync(20);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(1));
+            Assert.That(entity.IsDeleted, Is.False);
+            Assert.That(entity.DeletedAt, Is.Null);
+            Assert.That(entity.DeletedBy, Is.Null);
+        }
+
+        [Test]
+        public async Task RestoreAsync_IntId_NonSoftDeleteEntity_ReturnsZero()
+        {
+            // Arrange
+            var nonSoftDeleteLogger = Microsoft.Extensions.Logging.Abstractions.NullLogger<RepoBase<NonSoftDeleteEntity, TestDbContext>>.Instance;
+            var entity = new NonSoftDeleteEntity { Id = 20, Name = "Entity" };
+            _context.NonSoftDeleteEntities.Add(entity);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<NonSoftDeleteEntity, TestDbContext>(_context, nonSoftDeleteLogger);
+
+            // Act
+            var result = await repo.RestoreAsync(20);
+
+            // Assert - Non-ISoftDelete entities return 0
+            Assert.That(result, Is.EqualTo(0));
+        }
+
+        #endregion
+
+        #region RestoreAsync - long ID overload
+
+        [Test]
+        public async Task RestoreAsync_LongId_RestoresDeletedEntity()
+        {
+            // Arrange
+            var entity = new SoftDeleteEntity 
+            { 
+                Id = 21, 
+                Name = "Deleted Entity",
+                IsDeleted = true,
+                DeletedAt = DateTime.UtcNow,
+                DeletedBy = "TestUser"
+            };
+            _context.SoftDeleteEntities.Add(entity);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<SoftDeleteEntity, TestDbContext>(_context, _logger);
+
+            // Act
+            var result = await repo.RestoreAsync(21L);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(1));
+            Assert.That(entity.IsDeleted, Is.False);
+            Assert.That(entity.DeletedAt, Is.Null);
+            Assert.That(entity.DeletedBy, Is.Null);
+        }
+
+        #endregion
+
+        #region Integration - End to End
+
+        [Test]
+        public async Task SoftDeleteAndRestore_FullCycle()
+        {
+            // Arrange
+            var entity = new SoftDeleteEntity { Id = 100, Name = "Test Entity" };
+            _context.SoftDeleteEntities.Add(entity);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<SoftDeleteEntity, TestDbContext>(_context, _logger);
+
+            // Act - Soft delete
+            await repo.SoftDeleteAsync(100, "DeleterUser");
+
+            // Assert - Soft deleted
+            Assert.That(entity.IsDeleted, Is.True);
+            Assert.That(entity.DeletedBy, Is.EqualTo("DeleterUser"));
+
+            // Act - Restore
+            await repo.RestoreAsync(100);
+
+            // Assert - Restored
+            Assert.That(entity.IsDeleted, Is.False);
+            Assert.That(entity.DeletedAt, Is.Null);
+            Assert.That(entity.DeletedBy, Is.Null);
+        }
+
+        [Test]
+        public async Task SoftDelete_TimestampSetCorrectly()
+        {
+            // Arrange
+            var beforeDelete = DateTime.UtcNow.AddSeconds(-1);
+            var entity = new SoftDeleteEntity { Id = 101, Name = "Test Entity" };
+            _context.SoftDeleteEntities.Add(entity);
+            _context.SaveChanges();
+
+            var repo = new RepoBase<SoftDeleteEntity, TestDbContext>(_context, _logger);
+
+            // Act
+            await repo.SoftDeleteAsync(101, "TestUser");
+            var afterDelete = DateTime.UtcNow.AddSeconds(1);
+
+            // Assert
+            Assert.That(entity.DeletedAt, Is.Not.Null);
+            Assert.That(entity.DeletedAt, Is.GreaterThan(beforeDelete));
+            Assert.That(entity.DeletedAt, Is.LessThan(afterDelete));
+        }
+
+        #endregion
+
+        #region Test Infrastructure
+
+        public class TestDbContext : DbContext
+        {
+            public DbSet<SoftDeleteEntity> SoftDeleteEntities { get; set; } = null!;
+            public DbSet<NonSoftDeleteEntity> NonSoftDeleteEntities { get; set; } = null!;
+
+            public TestDbContext(DbContextOptions<TestDbContext> options) : base(options)
+            {
+            }
+        }
+
+        public class SoftDeleteEntity : ISoftDelete
+        {
+            public int Id { get; set; }
+            public string Name { get; set; } = string.Empty;
+            public bool? IsDeleted { get; set; }
+            public DateTime? DeletedAt { get; set; }
+            public string? DeletedBy { get; set; }
+        }
+
+        public class NonSoftDeleteEntity
+        {
+            public int Id { get; set; }
+            public string Name { get; set; } = string.Empty;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Closes #35

Adds comprehensive test coverage:
- SoftDeleteBehaviorTests (371 lines): soft delete, restore, deleted entity retrieval
- CacheBehaviorTests (431 lines): cache hit/miss, expiration, invalidation
- HighPerformanceRepoTests: bulk operations coverage

Total: 1514+ lines of focused tests.